### PR TITLE
Fix expense categories typo

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -88,7 +88,7 @@ const Settings = () => {
       details: true,
     },
     {
-      title: 'Exepnse Categories',
+      title: 'Expense Categories',
       icon: (
         <Icons.SquaresFour
           size={verticalScale(26)}


### PR DESCRIPTION
## Summary
- fix "Exepnse Categories" typo in the settings page

## Testing
- `npx jest` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686f4891be88832b8b683e3f7461397d