### PR TITLE
Remove duplicate uid filters

### DIFF
--- a/app/(modals)/transactionModal.tsx
+++ b/app/(modals)/transactionModal.tsx
@@ -111,7 +111,7 @@ const TransactionModal = () => {
   }, [oldTransaction?.walletId]);
   const walletConstraints = useMemo(() => {
     if (!user?.uid) return [];
-    return [where('uid', '==', user.uid), orderBy('created', 'desc')];
+    return [orderBy('created', 'desc')];
   }, [user?.uid]);
   const { data: wallets } = useFetchData<WalletType>(
     'wallets',

--- a/components/SearchableList.tsx
+++ b/components/SearchableList.tsx
@@ -37,7 +37,7 @@ const SearchableList: React.FC<SearchableListProps> = ({
 
   const constraints = useMemo(() => {
     if (!user?.uid) return [];
-    return [where('uid', '==', user.uid), orderBy('date', 'desc')];
+    return [orderBy('date', 'desc')];
   }, [user?.uid]);
 
   const {


### PR DESCRIPTION
## Summary
- remove redundant `uid` equality filter from search constraints
- remove redundant wallet query filter

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f48d0389c832b8cce4c0618b38b17