### PR TITLE
Add Jest tests for formatAmount

### DIFF
--- a/utils/__tests__/helper.test.ts
+++ b/utils/__tests__/helper.test.ts
@@ -1,0 +1,15 @@
+import { formatAmount } from '../helper';
+
+describe('formatAmount', () => {
+  it('formats amount without type', () => {
+    expect(formatAmount(1234.56)).toBe('$1,234.56');
+  });
+
+  it('formats income amount with plus prefix', () => {
+    expect(formatAmount(1234.56, 'income')).toBe('+$1,234.56');
+  });
+
+  it('formats expense amount with minus prefix', () => {
+    expect(formatAmount(1234.56, 'expense')).toBe('-$1,234.56');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `formatAmount` covering default, income, and expense cases

## Testing
- `npm test -- -w=0` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f49250aac832bb56e7c5313c446f2