### PR TITLE
Fix date handling for non-Firebase timestamps

### DIFF
--- a/components/TransactionList.tsx
+++ b/components/TransactionList.tsx
@@ -1,6 +1,5 @@
 import { FlashList } from '@shopify/flash-list';
 import { useRouter } from 'expo-router';
-import { Timestamp } from 'firebase/firestore';
 import { Icons } from '@/constants/icons';
 import React, { useEffect, useMemo, useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
@@ -11,6 +10,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { fetchUserCategories } from '@/services/transactionService';
 import useFetchData from '@/hooks/useFetchData';
+import { normalizeDate } from '@/utils/helper';
 import {
   CategoryType,
   TransactionItemProps,
@@ -83,9 +83,8 @@ function getCategory(
   const groupedTransactions = useMemo(() => {
     const map: Record<string, TransactionType[]> = {};
     data.forEach((item) => {
-      const dateStr = (item.date as Timestamp)
-        ?.toDate()
-        ?.toLocaleDateString('en-GB', { day: '2-digit', month: 'short' });
+      const dateStr = normalizeDate(item.date)
+        .toLocaleDateString('en-GB', { day: '2-digit', month: 'short' });
       if (!map[dateStr]) map[dateStr] = [];
       map[dateStr].push(item);
     });
@@ -103,7 +102,7 @@ function getCategory(
         type: item.type,
         amount: item.amount.toString(),
         category: item.category,
-        date: (item.date as Timestamp)?.toDate()?.toISOString(),
+        date: normalizeDate(item.date).toISOString(),
         description: item.description,
         image: item?.image,
         uid: item.uid,

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -9,6 +9,7 @@ import {
 import { getLast12Months, getLast7Days, getYearsRange } from '@/utils/common';
 import logger from '@/utils/logger';
 import { scale } from '@/utils/styling';
+import { normalizeDate } from '@/utils/helper';
 import {
   collection,
   deleteDoc,
@@ -534,8 +535,7 @@ export const fetchWeeklyStats = async (uid: string): Promise<ResponseType> => {
       const transaction = { id: doc.id, ...doc.data() } as TransactionType;
       transactions.push(transaction);
 
-      const transactionDate = (transaction.date as Timestamp)
-        .toDate()
+      const transactionDate = normalizeDate(transaction.date)
         .toISOString()
         .split('T')[0];
       const dayData = weeklyData.find((day) => day.date === transactionDate);
@@ -595,7 +595,7 @@ export const fetchMonthlyStats = async (uid: string): Promise<ResponseType> => {
       const transaction = { id: doc.id, ...doc.data() } as TransactionType;
       transactions.push(transaction);
 
-      const transactionDate = (transaction.date as Timestamp).toDate();
+      const transactionDate = normalizeDate(transaction.date);
       const monthName = transactionDate.toLocaleString('default', {
         month: 'short',
       });
@@ -670,9 +670,7 @@ export const fetchYearlyStats = async (uid: string): Promise<ResponseType> => {
       const transaction = { id: doc.id, ...doc.data() } as TransactionType;
       transactions.push(transaction);
 
-      const transactionYear = (transaction.date as Timestamp)
-        .toDate()
-        .getFullYear();
+      const transactionYear = normalizeDate(transaction.date).getFullYear();
       const yearData = yearlyData.find(
         (item: any) => item.year === transactionYear.toString(),
       );

--- a/utils/helper.ts
+++ b/utils/helper.ts
@@ -1,3 +1,5 @@
+import { Timestamp } from 'firebase/firestore';
+
 export function formatAmount(
   amount: number,
   type?: 'income' | 'expense',
@@ -12,4 +14,14 @@ export function formatAmount(
   }).format(amount);
 
   return `${prefix}${formatted}`;
+}
+
+export function normalizeDate(
+  value: Date | Timestamp | string,
+): Date {
+  if (value instanceof Date) return value;
+  if (typeof value === 'string') return new Date(value);
+  if (value instanceof Timestamp) return value.toDate();
+  // fallback for unexpected types
+  return new Date(value as any);
 }

--- a/utils/statisticsHelpers.ts
+++ b/utils/statisticsHelpers.ts
@@ -1,5 +1,5 @@
 import { MetricsType, TransactionType } from '@/types';
-import { Timestamp } from 'firebase/firestore';
+import { normalizeDate } from './helper';
 
 /**
  * Compute all analytics metrics from raw transactions.
@@ -24,7 +24,7 @@ export const computeSummaryMetrics = (
 
   const dailySpendMap = new Map<string, number>();
   expenses.forEach((t) => {
-    const date = (t.date as Timestamp).toDate().toISOString().split('T')[0];
+    const date = normalizeDate(t.date).toISOString().split('T')[0];
     dailySpendMap.set(date, (dailySpendMap.get(date) || 0) + t.amount);
   });
 
@@ -37,7 +37,7 @@ export const computeSummaryMetrics = (
   const mostActiveDay =
     [
       ...transactions.reduce((map, t) => {
-        const date = (t.date as Timestamp).toDate().toISOString().split('T')[0];
+        const date = normalizeDate(t.date).toISOString().split('T')[0];
         map.set(date, (map.get(date) || 0) + 1);
         return map;
       }, new Map<string, number>()),


### PR DESCRIPTION
## Summary
- add `normalizeDate` helper to safely convert strings and Dates
- use `normalizeDate` in statistics helpers, transaction service and transaction list

## Testing
- `npx tsc --noEmit` *(fails: Cannot find global value 'Promise' and other missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_686f4754ef20832b9fa5126e5290ce35